### PR TITLE
Fixed <code> marking in episode 308

### DIFF
--- a/episodes/308 - Oh My ZSH/en.html
+++ b/episodes/308 - Oh My ZSH/en.html
@@ -113,7 +113,7 @@ export PATH=/Users/eifion/.rvm/gems/ruby-1.9.2-p290/bin:/Users/eifion/.rvm/gems/
 
 <p>This file first sets the path to oh-my-zsh&rsquo;s configuration directory and then sets the theme, which is currently <code>robbyrussell</code>. Below this are some commented-out options so if, for example, we want to disable colours in directory listings we can uncomment the <code>DISABLE_LS_COLORS</code> option.</p> 
 
-<p>Further down the file is a list of the currently enabled plugins. We only have <code>git</code> enabled for now, but we&rsquo;ll add more shortly. The line below that, <code>source $ZSH/oh-my-zsh.sh</code>, loads oh-my-zsh and finally there&rsquo;s the line that configures our <code>PATH</code>. This defaults to whatever value it had when we installed oh-my-zsh but it&rsquo;s better to carry this over from our Bash profile. We can do this by removing the line that begins export <code>PATH</code> from <code>.zshrc</code> and then running this command.</p>
+<p>Further down the file is a list of the currently enabled plugins. We only have <code>git</code> enabled for now, but we&rsquo;ll add more shortly. The line below that, <code>source $ZSH/oh-my-zsh.sh</code>, loads oh-my-zsh and finally there&rsquo;s the line that configures our <code>PATH</code>. This defaults to whatever value it had when we installed oh-my-zsh but it&rsquo;s better to carry this over from our Bash profile. We can do this by removing the line that begins with <code>export PATH</code> from <code>.zshrc</code> and then running this command.</p>
 
 ``` terminal	
 ➜  ~  cat ~/.bash_profile >> ~/.zshrc

--- a/episodes/308 - Oh My ZSH/en.html
+++ b/episodes/308 - Oh My ZSH/en.html
@@ -113,7 +113,7 @@ export PATH=/Users/eifion/.rvm/gems/ruby-1.9.2-p290/bin:/Users/eifion/.rvm/gems/
 
 <p>This file first sets the path to oh-my-zsh&rsquo;s configuration directory and then sets the theme, which is currently <code>robbyrussell</code>. Below this are some commented-out options so if, for example, we want to disable colours in directory listings we can uncomment the <code>DISABLE_LS_COLORS</code> option.</p> 
 
-<p>Further down the file is a list of the currently enabled plugins. We only have <code>git</code> enabled for now, but we&rsquo;ll add more shortly. The line below that, source <code>$ZSH/oh-my-zsh.sh</code>, loads oh-my-zsh and finally there&rsquo;s the line that configures our <code>PATH</code>. This defaults to whatever value it had when we installed oh-my-zsh but it&rsquo;s better to carry this over from our Bash profile. We can do this by removing the line that begins export <code>PATH</code> from <code>.zshrc</code> and then running this command.</p>
+<p>Further down the file is a list of the currently enabled plugins. We only have <code>git</code> enabled for now, but we&rsquo;ll add more shortly. The line below that, <code>source $ZSH/oh-my-zsh.sh</code>, loads oh-my-zsh and finally there&rsquo;s the line that configures our <code>PATH</code>. This defaults to whatever value it had when we installed oh-my-zsh but it&rsquo;s better to carry this over from our Bash profile. We can do this by removing the line that begins export <code>PATH</code> from <code>.zshrc</code> and then running this command.</p>
 
 ``` terminal	
 ➜  ~  cat ~/.bash_profile >> ~/.zshrc


### PR DESCRIPTION
In episode 308, there is a line explaining code from the .zshrc file. It had a wrong <code>...</code> marking 
(the command _source_ was left outside of the formatted code block). 

Same for export PATH code (also fixed grammar there).
